### PR TITLE
verify を自動化しましょう

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+compiler:
+    - clang
+    - gcc
+dist: xenial
+addons:
+    apt:
+        packages:
+            - python3
+            - python3-pip
+            - python3-setuptools
+
+before_install:
+    - pip3 install -U setuptools
+    - pip3 install -U online-judge-tools=='6.*'
+script:
+    - ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Travis](https://img.shields.io/travis/ei1333/library/master.svg)](https://travis-ci.org/ei1333/library)
+
 たぴ

--- a/dp/verify/aoj-dpl-1-d.cpp
+++ b/dp/verify/aoj-dpl-1-d.cpp
@@ -1,8 +1,0 @@
-int main() {
-  int N;
-  cin >> N;
-  vector< int > A(N);
-  cin >> A;
-  cout << longest_increasing_subsequence(A, true) << endl;
-}
-

--- a/dp/verify/aoj-dpl-1-d.test.cpp
+++ b/dp/verify/aoj-dpl-1-d.test.cpp
@@ -1,0 +1,19 @@
+#include <bits/stdc++.h>
+using namespace std;
+#define main moin
+#define $END$
+#include "../../template/template.cpp"
+#undef $END$
+#undef main
+
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_1_D"
+#include "../longest-increasing-subsequence.cpp"
+
+int main() {
+  int N;
+  cin >> N;
+  vector< int > A(N);
+  cin >> A;
+  cout << longest_increasing_subsequence(A, true) << endl;
+}
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+which oj > /dev/null || { echo 'ERROR: please install `oj'\'' with: $ pip3 install --user -U online-judge-tools=='\''6.*'\''' >& 1 ; exit 1 ; }
+
+CXX=${CXX:-g++}
+CXXFLAGS="${CXXFLAGS:--std=c++14 -O2 -Wall -g}"
+ulimit -s unlimited
+
+
+list-dependencies() {
+    file="$1"
+    $CXX $CXXFLAGS -I . -MD -MF /dev/stdout -MM "$file" | sed '1s/[^:].*: // ; s/\\$//' | xargs -n 1
+}
+
+list-defined() {
+    file="$1"
+    $CXX $CXXFLAGS -I . -dM -E "$file"
+}
+
+get-url() {
+    file="$1"
+    list-defined "$file" | grep '^#define PROBLEM ' | sed 's/^#define PROBLEM "\(.*\)"$/\1/'
+}
+
+is-verified() {
+    file="$1"
+    cache=test/timestamp/$(echo -n "$file" | md5sum | sed 's/ .*//')
+    timestamp="$(list-dependencies "$file" | xargs -I '{}' find "$file" '{}' -printf "%T+\t%p\n" | sort -nr | head -n 1 | cut -f 2)"
+    [[ -e $cache ]] && [[ $timestamp -ot $cache ]]
+}
+
+mark-verified() {
+    file="$1"
+    cache=test/timestamp/$(echo -n "$file" | md5sum | sed 's/ .*//')
+    mkdir -p test/timestamp
+    touch $cache
+}
+
+list-recently-updated() {
+    for file in $(find . -name \*.test.cpp) ; do
+        list-dependencies "$file" | xargs -n 1 | while read f ; do
+            git log -1 --format="%ci	${file}" "$f"
+        done | sort -nr | head -n 1
+    done | sort -nr | head -n 20 | cut -f 2
+}
+
+run() {
+    file="$1"
+    url="$(get-url "$file")"
+    dir=test/$(echo -n "$url" | md5sum | sed 's/ .*//')
+    mkdir -p ${dir}
+
+    # ignore if IGNORE is defined
+    if list-defined "$file" | grep '^#define IGNORE ' > /dev/null ; then
+        return
+    fi
+
+    if ! is-verified "$file" ; then
+        # compile
+        $CXX $CXXFLAGS -I . -o ${dir}/a.out "$file"
+        if [[ -n ${url} ]] ; then
+            # download
+            if [[ ! -e ${dir}/test ]] ; then
+                sleep 2
+                oj download --system "$url" -d ${dir}/test
+            fi
+            # test
+            oj test -c ${dir}/a.out -d ${dir}/test
+        else
+            # run
+            ${dir}/a.out
+        fi
+        mark-verified "$file"
+    fi
+}
+
+
+if [[ $# -eq 1 && ( $1 = -h || $1 = --help || $1 = -? ) ]] ; then
+    echo Usage: $0 '[FILE ...]'
+    echo 'Compile and Run specified C++ code.'
+    echo 'If the given code contains macro like `#define PROBLEM "https://..."'\'', Download test cases of the problem and Test with them.'
+    echo
+    echo 'Features:'
+    echo '-   glob files with "**/*.test.cpp" if no arguments given.'
+    echo '-   cache results of tests, analyze "#include <...>" relations, and execute tests if and only if necessary.'
+    echo '-   on CI environment (i.e. $CI is defined), only recently modified files are tested (without cache).'
+
+elif [[ $# -eq 0 ]] ; then
+    if [[ $CI ]] ; then
+        # CI
+        for f in $(list-recently-updated) ; do
+            run $f
+        done
+
+    else
+        # local
+        for f in $(find . -name \*.test.cpp) ; do
+            run $f
+        done
+    fi
+else
+    # specified
+    for f in "$@" ; do
+        run "$f"
+    done
+fi


### PR DESCRIPTION
ライブラリの verify を自動化しましょう。
このプルリクをマージして https://travis-ci.org/ から設定すれば、push するたびにいい感じにテストがされるようになります (例: https://travis-ci.org/beet-aizu/library )。
`.test.cpp` で終わる名前のファイルを置いて `#define PROBLEM "https://..."` のように AOJ の問題を指定 (例: https://github.com/beet-aizu/library/blob/e4ca8f9e14e23a8ccdc278be1a5d6369a83c1863/test/aoj/DPL_5_A.test.cpp ) しておくと自動でテストケースを落としてきてコンパイルして実行して AC を確認してくれます。

より詳しいドキュメントは https://online-judge-tools.readthedocs.io/en/master/run-ci-on-your-library.html にあります。