### PR TITLE
fix knapsack-limitations-2

### DIFF
--- a/dp/knapsack-limitations-2.cpp
+++ b/dp/knapsack-limitations-2.cpp
@@ -30,7 +30,7 @@ T knapsack_limitations(const vector< T > &w, const vector< T > &m, const vector<
     T rest = W - dp[i], cost = i;
     for(auto &p : ord) {
       auto get = min(mb[p], rest / w[p]);
-      if(get == 0) break;
+      if(get <= 0) continue;
       cost += get * v[p];
       rest -= get * w[p];
     }


### PR DESCRIPTION
mb が 0 の時に本当はそれより効率悪いやつ取ってこないと最適でないのに break; している

verify:
[bug] https://atcoder.jp/contests/arc096/submissions/28027896
[fixed] https://atcoder.jp/contests/arc096/submissions/28027908