### PR TITLE
fix/li chao tree doc rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@ implementations. Keep each task focused on one feature or one coherent change.
 - Document the overview, API signature, behavior, constraints or
   preconditions, and time and space complexity. Include other sections from the
   template when applicable.
+- Do not write a literal `|` inside inline math because the documentation
+  renderer may interpret it as a Markdown table delimiter. Prefer a named
+  variable, or write absolute values with LaTeX commands such as
+  `\lvert x \rvert`.
 - After changing Markdown documentation, run:
 
   ```console

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,7 @@ implementations. Keep each task focused on one feature or one coherent change.
   template when applicable.
 - Do not write a literal `|` inside inline math because the documentation
   renderer may interpret it as a Markdown table delimiter. Prefer a named
-  variable, or write absolute values with LaTeX commands such as
-  `\lvert x \rvert`.
+  variable, or escape vertical bars in absolute values, such as `\|x\|`.
 - After changing Markdown documentation, run:
 
   ```console

--- a/docs/li-chao-tree.md
+++ b/docs/li-chao-tree.md
@@ -11,6 +11,7 @@ documentation_of: //structure/convex-hull-trick/li-chao-tree.hpp
 
 ## 記法
 
+- $m$: コンストラクタに渡した座標の個数
 - $n$: コンストラクタに渡した座標の重複を除いた個数
 
 # コンストラクタ
@@ -28,13 +29,13 @@ LiChaoTree(const vector<T>& x, T INF)
 
 ## 制約
 
-- $1 \leq |x|$
+- $1 \leq m$
 - `INF` はすべてのクエリ結果以上
 - 直線の値 $ax+b$ は `T` で表現できる
 
 ## 計算量
 
-- 時間計算量: $O(|x| \log |x|)$
+- 時間計算量: $O(m \log m)$
 - 空間計算量: $O(n)$
 
 # update


### PR DESCRIPTION
- Fix Li Chao tree documentation rendering
- Document safe math delimiter syntax
- Use escaped bars in documentation guidance
