### PR TITLE
Fix red-black tree

### DIFF
--- a/structure/bbst/lazy-red-black-tree.hpp
+++ b/structure/bbst/lazy-red-black-tree.hpp
@@ -80,7 +80,18 @@ struct LazyRedBlackTree {
   }
 
   Node* submerge(Node* l, Node* r) {
-    if (l->level < r->level) {
+    if (l->level == r->level) {
+      if (l->color != r->color) {
+        if (l->color == RED) {
+          l = propagate(l);
+          l->color = BLACK;
+        } else {
+          r = propagate(r);
+          r->color = BLACK;
+        }
+      }
+      return alloc(l, r);
+    } else if (l->level < r->level) {
       r = propagate(r);
       Node* c = (r->l = submerge(l, r->l));
       if (r->color == BLACK && c->color == RED && c->l && c->l->color == RED) {
@@ -90,8 +101,7 @@ struct LazyRedBlackTree {
         r->r->color = BLACK;
       }
       return update(r);
-    }
-    if (l->level > r->level) {
+    } else {
       l = propagate(l);
       Node* c = (l->r = submerge(l->r, r));
       if (l->color == BLACK && c->color == RED && c->r && c->r->color == RED) {
@@ -102,7 +112,6 @@ struct LazyRedBlackTree {
       }
       return update(l);
     }
-    return alloc(l, r);
   }
 
   Node* build(int l, int r, const vector<Monoid>& v) {

--- a/structure/bbst/red-black-tree.hpp
+++ b/structure/bbst/red-black-tree.hpp
@@ -54,7 +54,18 @@ struct RedBlackTree {
   }
 
   Node* submerge(Node* l, Node* r) {
-    if (l->level < r->level) {
+    if (l->level == r->level) {
+      if (l->color != r->color) {
+        if (l->color == RED) {
+          l = clone(l);
+          l->color = BLACK;
+        } else {
+          r = clone(r);
+          r->color = BLACK;
+        }
+      }
+      return alloc(l, r);
+    } else if (l->level < r->level) {
       r = clone(r);
       Node* c = (r->l = submerge(l, r->l));
       if (r->color == BLACK && c->color == RED && c->l && c->l->color == RED) {
@@ -64,8 +75,7 @@ struct RedBlackTree {
         r->r->color = BLACK;
       }
       return update(r);
-    }
-    if (l->level > r->level) {
+    } else {
       l = clone(l);
       Node* c = (l->r = submerge(l->r, r));
       if (l->color == BLACK && c->color == RED && c->r && c->r->color == RED) {
@@ -76,7 +86,6 @@ struct RedBlackTree {
       }
       return update(l);
     }
-    return alloc(l, r);
   }
 
   Node* build(int l, int r, const vector<Monoid>& v) {


### PR DESCRIPTION
根が黒の木と根が赤の木がマージされる際、それぞれの `level` が等しいと正しくない赤黒木が生成されてしまいます。

根を赤→黒と書き換えても問題ないのでマージ前に黒にしておく必要がありそうです。

<img width="921" height="335" alt="image" src="https://github.com/user-attachments/assets/0ca281b9-30dc-47ce-85b1-2c20ac4249db" />

詳細: https://x.com/kzlogos/status/2084642226697900063

## 動作確認

```cpp
int main() {
	auto f = [](int a, int b) { return min(a, b); };
	RedBlackTree< int, decltype(f) > rbt(200000, f, inf);
	vector<int> A(1);
	auto root = rbt.build(A);

	rbt.insert(root, 0, 1);
	rbt.insert(root, 0, 2);
	rbt.insert(root, 0, 3);
	rbt.insert(root, 2, -1);

	for (int i = 0; i < 10000; i++)
	{
		rbt.insert(root, i, i);
	}

	cout << "left[Size=" << root->l->cnt << " Level=" << root->l->level << "] right[Size=" << root->r->cnt << " Level=" << root->r->level << "]\n";
	// 修正前: left[Size=16 Level=4] right[Size=9989 Level=4] 
	// 修正後: left[Size=4096 Level=12] right[Size=5909 Level=12]
}
```